### PR TITLE
feat: update baseURL

### DIFF
--- a/client.go
+++ b/client.go
@@ -13,7 +13,7 @@ import (
 	"time"
 )
 
-const defaultBaseURL = "https://porkbun.com/api/json/v3/"
+const defaultBaseURL = "https://api.porkbun.com/api/json/v3/"
 
 const statusSuccess = "SUCCESS"
 


### PR DESCRIPTION
Updated as per [Porkbun docs](https://porkbun.com/api/json/v3/documentation#apiHost )

> API Hostname: api.porkbun.com
> Please note that porkbun.com currently works and has historically been the correct hostname for our API. However, we will be migrating away from that hostname and the API will no function using it at some point in the future.