### PR TITLE
feat: allow creating a client with a custom timeout

### DIFF
--- a/client.go
+++ b/client.go
@@ -31,13 +31,18 @@ type Client struct {
 
 // New creates a new Client.
 func New(secretAPIKey, apiKey string) *Client {
+	return NewWithTimeout(secretAPIKey, apiKey, 10*time.Second)
+}
+
+// NewWithTimeout creates a new Client with a timeout.
+func NewWithTimeout(secretAPIKey, apiKey string, timeout time.Duration) *Client {
 	baseURL, _ := url.Parse(defaultBaseURL)
 
 	return &Client{
 		secretAPIKey: secretAPIKey,
 		apiKey:       apiKey,
 		BaseURL:      baseURL,
-		HTTPClient:   &http.Client{Timeout: 10 * time.Second},
+		HTTPClient:   &http.Client{Timeout: timeout},
 	}
 }
 


### PR DESCRIPTION
I would like to be able to define a custom timeout for the client. I'm currently consistently getting timeout errors in one of my projects and I think I can relax the timeout and/or make it configurable. 